### PR TITLE
Add dark mode theme toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,13 +69,19 @@
         button:hover {
             background: #e9ecef;
         }
-        
+
         button.active {
             background: #007bff;
             color: white;
             border-color: #007bff;
         }
-        
+
+        .theme-toggle {
+            position: absolute;
+            top: 20px;
+            right: 20px;
+        }
+
         .day-buttons {
             display: flex;
             gap: 5px;
@@ -225,6 +231,71 @@
                 padding: 8px;
             }
         }
+
+        body.dark-mode {
+            background-color: #121212;
+            color: #e0e0e0;
+        }
+
+        body.dark-mode .container {
+            background: #1e1e1e;
+            color: #e0e0e0;
+        }
+
+        body.dark-mode .filters {
+            background: #2a2a2a;
+            border-bottom-color: #555;
+        }
+
+        body.dark-mode input[type="text"],
+        body.dark-mode input[type="number"] {
+            background: #333;
+            border-color: #555;
+            color: #e0e0e0;
+        }
+
+        body.dark-mode button {
+            background: #333;
+            border-color: #555;
+            color: #e0e0e0;
+        }
+
+        body.dark-mode button:hover {
+            background: #444;
+        }
+
+        body.dark-mode .sessions-table th {
+            background: #2a2a2a;
+            color: #e0e0e0;
+            border-bottom-color: #555;
+        }
+
+        body.dark-mode .sessions-table td {
+            border-bottom-color: #555;
+        }
+
+        body.dark-mode .sessions-table tr:hover {
+            background: #333;
+        }
+
+        body.dark-mode .table-container {
+            border-bottom-color: #555;
+        }
+
+        body.dark-mode .session-details {
+            background: #2a2a2a;
+            border-top-color: #555;
+        }
+
+        body.dark-mode .session-details h3 {
+            color: #f1f1f1;
+        }
+
+        body.dark-mode .session-count {
+            background: #333;
+            color: #ccc;
+        }
+
     </style>
 </head>
 <body>
@@ -232,6 +303,7 @@
         <div class="header">
             <h1>Conference Session Browser</h1>
             <p style="margin: 5px 0 0 0; opacity: 0.9; font-size: 16px;">Snowflake Summit 2025 • June 2-5 • San Francisco</p>
+            <button id="themeToggle" class="theme-toggle" onclick="toggleTheme()">Dark Mode</button>
         </div>
         
         <div class="filters">
@@ -907,8 +979,28 @@
             applyFilters();
         }
 
-        // Load sessions on page load
-        document.addEventListener('DOMContentLoaded', loadSessions);
+        // Theme toggle
+        function applySavedTheme() {
+            const saved = localStorage.getItem('theme');
+            if (saved === 'dark') {
+                document.body.classList.add('dark-mode');
+                document.getElementById('themeToggle').textContent = 'Light Mode';
+            } else {
+                document.getElementById('themeToggle').textContent = 'Dark Mode';
+            }
+        }
+
+        function toggleTheme() {
+            const isDark = document.body.classList.toggle('dark-mode');
+            document.getElementById('themeToggle').textContent = isDark ? 'Light Mode' : 'Dark Mode';
+            localStorage.setItem('theme', isDark ? 'dark' : 'light');
+        }
+
+        // Load sessions and theme on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            loadSessions();
+            applySavedTheme();
+        });
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add dark mode styles and toggle button to the UI
- remember theme preference in localStorage

## Testing
- `python3 -m py_compile browse_sessions.py fix_dates.py serve.py`

------
https://chatgpt.com/codex/tasks/task_e_68438b6c8068832fa9d8b77eacb86b65