### PR TITLE
Update layout to side-by-side list and details

### DIFF
--- a/index.html
+++ b/index.html
@@ -186,18 +186,26 @@
         .sessions-table tr.selected {
             background: #e3f2fd;
         }
+
+        .main-content {
+            display: flex;
+            gap: 20px;
+        }
         
         .table-container {
             max-height: 400px;
             overflow-y: auto;
             border-bottom: 1px solid #ddd;
+            flex: 1;
+            border-right: 1px solid #ddd;
         }
         
         .session-details {
             padding: 20px;
             background: #f8f9fa;
-            border-top: 1px solid #ddd;
+            border-left: 1px solid #ddd;
             min-height: 200px;
+            flex: 1;
         }
         
         .session-details h3 {
@@ -257,6 +265,28 @@
             .sessions-table th, .sessions-table td {
                 padding: 8px;
             }
+
+            .main-content {
+                flex-direction: column;
+            }
+
+            .table-container {
+                border-right: none;
+                border-bottom: 1px solid #ddd;
+            }
+
+            .session-details {
+                border-left: none;
+                border-top: 1px solid #ddd;
+            }
+
+            body.dark-mode .table-container {
+                border-bottom-color: #555;
+            }
+
+            body.dark-mode .session-details {
+                border-top-color: #555;
+            }
         }
 
         body.dark-mode {
@@ -307,11 +337,12 @@
 
         body.dark-mode .table-container {
             border-bottom-color: #555;
+            border-right-color: #555;
         }
 
         body.dark-mode .session-details {
             background: #2a2a2a;
-            border-top-color: #555;
+            border-left-color: #555;
         }
 
         body.dark-mode .session-details h3 {
@@ -416,9 +447,10 @@
             Loading sessions...
         </div>
         <canvas id="resultSparkline" width="200" height="40" style="display:block;margin:10px auto;"></canvas>
-        
-        <div class="table-container">
-            <table class="sessions-table">
+
+        <div class="main-content">
+            <div class="table-container">
+                <table class="sessions-table">
                 <thead>
                     <tr>
                         <th style="width: 50%">Title</th>
@@ -429,10 +461,12 @@
                 <tbody id="sessionsTableBody">
                 </tbody>
             </table>
+            </div>
+
+            <div class="session-details" id="sessionDetails">
+                <p>Select a session to view details</p>
+            </div>
         </div>
-        
-        <div class="session-details" id="sessionDetails">
-            <p>Select a session to view details</p>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- restructure layout so the session list and details sit side by side
- adjust CSS for new flexbox layout
- keep mobile layout stacked via media query
- update dark mode borders

## Testing
- `python3 -m py_compile browse_sessions.py serve.py fix_dates.py`

------
https://chatgpt.com/codex/tasks/task_e_68438dfcf774832f8f38be2e32b4ec64