### PR TITLE
Add shareable session links

### DIFF
--- a/index.html
+++ b/index.html
@@ -749,7 +749,8 @@
             
             filteredSessions.forEach(session => {
                 const row = document.createElement('tr');
-                row.onclick = () => selectSession(session);
+                row.dataset.id = session.id;
+                row.onclick = () => selectSession(session, row);
                 row.innerHTML = `
                     <td>${escapeHtml(session.title || '')}</td>
                     <td>${escapeHtml(session.date || '')}</td>
@@ -760,17 +761,21 @@
         }
 
         // Select a session and show details
-        function selectSession(session) {
+        function selectSession(session, rowElem) {
             // Remove previous selection
             document.querySelectorAll('.sessions-table tr').forEach(row => {
                 row.classList.remove('selected');
             });
-            
-            // Add selection to clicked row
-            event.currentTarget.classList.add('selected');
-            
+
+            // Add selection to clicked row or lookup row by id
+            const row = rowElem || document.querySelector(`tr[data-id='${session.id}']`);
+            if (row) {
+                row.classList.add('selected');
+            }
+
             selectedSessionId = session.id;
             showSessionDetails(session);
+            window.location.hash = `session-${session.id}`;
         }
 
         // Show session details
@@ -807,6 +812,19 @@
         function clearSessionDetails() {
             document.getElementById('sessionDetails').innerHTML = '<p>Select a session to view details</p>';
             selectedSessionId = null;
+        }
+
+        // Load session from URL hash if present
+        function loadSessionFromHash() {
+            const match = window.location.hash.match(/^#session-(\d+)$/);
+            if (match) {
+                const id = parseInt(match[1]);
+                const session = allSessions.find(s => s.id === id);
+                if (session) {
+                    const row = document.querySelector(`tr[data-id='${id}']`);
+                    selectSession(session, row);
+                }
+            }
         }
 
         // Filter by day
@@ -1097,6 +1115,8 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     loadSessions();
     applySavedTheme();
+    loadSessionFromHash();
+    window.addEventListener('hashchange', loadSessionFromHash);
 });
     </script>
 </body>


### PR DESCRIPTION
## Summary
- allow session rows to hold the id and pass it to selection function
- update selection to highlight a row, set the URL fragment and handle direct calls
- support loading a session from the `#session-<id>` fragment
- read fragment on page load and react to `hashchange`

## Testing
- `python3 -m py_compile serve.py`

------
https://chatgpt.com/codex/tasks/task_e_684391581a74832fa8717b061f625ba5